### PR TITLE
Feature: Add single-flight detector strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,48 @@ an existing solution.
 
 [![Anicetus Video](https://img.youtube.com/vi/vInKlTQMKBc/0.jpg)](https://www.youtube.com/watch?v=vInKlTQMKBc)
 
+## When (not) to use this
+
+The thundering herd is a real problem, but a lot of stacks already solve it
+somewhere else. Before reaching for Anicetus, check whether one of these already
+covers you:
+
+| Alternative | How it handles the herd | When it's the better fit |
+|---|---|---|
+| **CDN origin shielding / request collapsing** (Cloudflare, Fastly, CloudFront) | Collapses concurrent cache misses at the edge, transparently | You already front cacheable `GET`s with a CDN — this is free and needs no code |
+| **In-process single-flight** ([`golang.org/x/sync/singleflight`](https://pkg.go.dev/golang.org/x/sync/singleflight), `groupcache`) | Deduplicates identical in-flight calls inside one process | A single service instance, or per-instance dedup is enough |
+| **`stale-while-revalidate`** (HTTP caching / CDNs) | Serves stale content while one request refreshes in the background | The response can be briefly stale and you control the cache headers |
+| **Probabilistic early expiration** (XFetch) | Recomputes a hot key *before* it expires, spreading the load out | You own the cache layer and can add jitter to TTLs |
+
+**Anicetus fits the gap those leave:** coordinating a single request through to
+the backend *across processes*, in front of a backend you can't easily change,
+without a CDN doing it for you. Concretely, it earns its place when:
+
+- The backend has **no CDN** in front (internal services, B2B APIs, DB-backed
+  endpoints, gRPC-ish internal traffic).
+- You run **multiple instances** and need cross-instance coalescing that
+  in-process `singleflight` can't give you (use the Redis detector and storage).
+- The expensive operation is **cacheable and dramatically more expensive** than
+  the coordination overhead (heavy aggregations, rate-limited third-party calls,
+  ML inference).
+
+**It won't help — or will actively hurt — when:**
+
+- The response **isn't cacheable** (personalized, per-user, or a write). Blocking
+  then releasing only time-shifts the herd; it doesn't remove it.
+- The **fingerprint can't be aligned with the backend's cache key** (auth,
+  cookies, `Vary` headers, query normalization). A mismatch either over-coalesces
+  unrelated requests or lets the herd leak anyway.
+- Traffic is **low enough that a stampede never forms** — you'd be paying
+  detector/gatekeeper overhead on every request for a problem you don't have.
+
+> [!NOTE]
+> The default token bucket detector is a *threshold* strategy: it only engages
+> once concurrent traffic for a fingerprint exceeds the configured burst, so the
+> first burst reaches the backend by design. If you want to guarantee that no
+> more than one request per fingerprint hits the backend — even a herd of two —
+> use the single-flight detector instead (see below).
+
 ## Design
 
 ```mermaid
@@ -72,6 +114,18 @@ bucket](https://en.wikipedia.org/wiki/Token_bucket) out-of-the-box (with a
 penalty strategy; bucket is drained while in thundering herd). When using the
 token bucket algorithm the detector needs to know how many same fingerprint
 occurences are allowed in a time window.
+
+Alternatively, the library provides a **single-flight** detector
+(`NewSingleFlightInMemory`, or the Redis-backed storage for the distributed
+case). It has no burst threshold: it treats a fingerprint as a thundering herd
+from the very first duplicate, so the gatekeeper lets exactly one request reach
+the backend and blocks every concurrent request with the same fingerprint. This
+is the deterministic equivalent of
+[`golang.org/x/sync/singleflight`](https://pkg.go.dev/golang.org/x/sync/singleflight),
+but coordinated through the gatekeeper storage so it works across processes.
+Prefer it when a burst of concurrent requests reaching the backend is *not*
+acceptable; prefer the token bucket when it is and you only want to engage above
+a threshold.
 
 After the thundering herd is handled, the detector will stop analysing the
 requests for a while (cooldown period). This is to avoid the thundering herd to

--- a/detector/options.go
+++ b/detector/options.go
@@ -102,3 +102,46 @@ func TokenBucketWithLimitersInterval(interval time.Duration) TokenBucketOption {
 		o.limitersInterval = interval
 	}
 }
+
+// SingleFlightOptions represents the options that can be used to configure a
+// single-flight strategy.
+type SingleFlightOptions struct {
+	Options
+
+	coolDownInterval time.Duration
+}
+
+// NewSingleFlightOptions creates a new SingleFlightOptions with default values.
+func NewSingleFlightOptions() *SingleFlightOptions {
+	return &SingleFlightOptions{
+		Options: *NewOptions(),
+
+		coolDownInterval: 5 * time.Minute,
+	}
+}
+
+// CoolDownInterval returns the cooldown interval for the SingleFlightOptions.
+func (o *SingleFlightOptions) CoolDownInterval() time.Duration {
+	return o.coolDownInterval
+}
+
+// SingleFlightOption is a helper function to configure the SingleFlightOptions.
+type SingleFlightOption func(*SingleFlightOptions)
+
+// SingleFlightWithBasicOption sets the basic options for the
+// SingleFlightOptions.
+func SingleFlightWithBasicOption(options ...Option) SingleFlightOption {
+	return func(o *SingleFlightOptions) {
+		for _, opt := range options {
+			opt(&o.Options)
+		}
+	}
+}
+
+// SingleFlightWithCoolDownInterval sets the cooldown interval for the
+// SingleFlightOptions.
+func SingleFlightWithCoolDownInterval(interval time.Duration) SingleFlightOption {
+	return func(o *SingleFlightOptions) {
+		o.coolDownInterval = interval
+	}
+}

--- a/detector/redigo/tokenbucket_redis_test.go
+++ b/detector/redigo/tokenbucket_redis_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -36,19 +35,22 @@ func TestTokenBucketRedis_IsThunderingHerd(t *testing.T) {
 		},
 	}, {
 		burst:    4,
-		interval: 500 * time.Millisecond,
+		interval: 2 * time.Second,
 		cycles:   6,
 		cycleSleep: func(cycle int) time.Duration {
-			if cycle == 6 {
-				// sleep longer to allow populating 1 token and avoid thundering herd
-				return 500 * time.Millisecond
+			if cycle == 5 {
+				// wait more than one refill period so a single token is restored,
+				// allowing cycle 6 through again
+				return 2100 * time.Millisecond
 			}
-			return 100 * time.Millisecond
+			// negligible refill while draining the bucket; the wide margin keeps
+			// the result independent of Redis round-trip latency
+			return 10 * time.Millisecond
 		},
 		want: func(cycle int) bool {
-			// this may fail if the I/O with Redis is too slow, as the filling rate
-			// will give a chance for cycle 5
-			return slices.Contains([]int{5, 6}, cycle)
+			// cycles 1-4 drain the bucket, cycle 5 finds it empty (thundering
+			// herd), and the refill wait lets cycle 6 through again
+			return cycle == 5
 		},
 	}}
 

--- a/detector/singleflight_inmemory.go
+++ b/detector/singleflight_inmemory.go
@@ -1,0 +1,67 @@
+package detector
+
+import (
+	"context"
+
+	"github.com/rafaeljusto/anicetus/v2"
+	"github.com/rafaeljusto/anicetus/v2/internal/mapexp"
+)
+
+var _ anicetus.Detector = &SingleFlightInMemory{}
+
+// SingleFlightInMemory is a detector strategy that coalesces every concurrent
+// duplicate of a fingerprint, storing the state in memory.
+//
+// Unlike the token bucket strategy, it has no burst threshold to cross: it
+// treats a fingerprint as a thundering herd from the very first duplicate. The
+// gatekeeper then elects a single request to reach the backend (StatusProcess)
+// and makes every concurrent request with the same fingerprint wait
+// (StatusWait) until that request finishes. This is the deterministic
+// equivalent of golang.org/x/sync/singleflight, but coordinated through the
+// gatekeeper storage so it can work across processes (see the Redis storage).
+//
+// Use this when you want to guarantee that no more than one request per
+// fingerprint reaches the backend at a time, even for a herd of two. Prefer the
+// token bucket strategy when a burst of concurrent requests is acceptable and
+// you only want to engage once traffic crosses a threshold.
+//
+// Every distinct fingerprint touches the gatekeeper storage once per cooldown
+// window, so memory/storage usage grows with fingerprint cardinality. Keep the
+// fingerprint aligned with the backend cache key to avoid over-coalescing
+// unrelated requests.
+type SingleFlightInMemory struct {
+	cooldowns *mapexp.Map[anicetus.Fingerprint, bool]
+}
+
+// NewSingleFlightInMemory creates a new single-flight detector strategy.
+func NewSingleFlightInMemory(options ...SingleFlightOption) *SingleFlightInMemory {
+	o := NewSingleFlightOptions()
+	for _, opt := range options {
+		opt(o)
+	}
+
+	return &SingleFlightInMemory{
+		cooldowns: mapexp.New[anicetus.Fingerprint, bool](o.CoolDownInterval()),
+	}
+}
+
+// CoolDown will cool down the fingerprint.
+func (s *SingleFlightInMemory) CoolDown(_ context.Context, fingerprint anicetus.Fingerprint) error {
+	s.cooldowns.Set(fingerprint, true)
+	return nil
+}
+
+// IsCoolDown checks if the fingerprint is in cooldown.
+func (s *SingleFlightInMemory) IsCoolDown(_ context.Context, fingerprint anicetus.Fingerprint) (bool, error) {
+	cooldown, ok := s.cooldowns.Get(fingerprint)
+	return cooldown && ok, nil
+}
+
+// IsThunderingHerd always reports a thundering herd. Coalescing is delegated to
+// the gatekeeper, which lets the first request through and blocks the rest, so
+// there is no threshold to detect here. Requests are only allowed straight
+// through while the fingerprint is in cooldown (see Evaluate), which is when the
+// backend cache is assumed to be warm.
+func (s *SingleFlightInMemory) IsThunderingHerd(_ context.Context, _ anicetus.Fingerprint) (bool, error) {
+	return true, nil
+}

--- a/detector/singleflight_inmemory_test.go
+++ b/detector/singleflight_inmemory_test.go
@@ -1,0 +1,49 @@
+package detector_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rafaeljusto/anicetus/v2"
+	"github.com/rafaeljusto/anicetus/v2/detector"
+)
+
+func TestSingleFlightInMemory_IsThunderingHerd(t *testing.T) {
+	d := detector.NewSingleFlightInMemory()
+
+	// A single-flight detector engages from the very first request, with no
+	// burst to warm up first.
+	for i := 0; i < 5; i++ {
+		herd, err := d.IsThunderingHerd(t.Context(), anicetus.Fingerprint("test"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !herd {
+			t.Errorf("cycle %d: expected thundering herd to always be reported", i)
+		}
+	}
+}
+
+func TestSingleFlightInMemory_CoolDown(t *testing.T) {
+	d := detector.NewSingleFlightInMemory(
+		detector.SingleFlightWithCoolDownInterval(time.Minute),
+	)
+
+	fingerprint := anicetus.Fingerprint("test")
+
+	if cooldown, err := d.IsCoolDown(t.Context(), fingerprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if cooldown {
+		t.Error("expected fingerprint to not be in cooldown before it is set")
+	}
+
+	if err := d.CoolDown(t.Context(), fingerprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cooldown, err := d.IsCoolDown(t.Context(), fingerprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !cooldown {
+		t.Error("expected fingerprint to be in cooldown after it is set")
+	}
+}

--- a/detector/tokenbucket_inmemory_test.go
+++ b/detector/tokenbucket_inmemory_test.go
@@ -2,7 +2,6 @@ package detector_test
 
 import (
 	"fmt"
-	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -27,17 +26,21 @@ func TestTokenBucketInMemory_IsThunderingHerd(t *testing.T) {
 		},
 	}, {
 		burst:    4,
-		interval: 500 * time.Millisecond,
-		cycles:   7,
+		interval: 2 * time.Second,
+		cycles:   6,
 		cycleSleep: func(cycle int) time.Duration {
-			if cycle == 6 {
-				// sleep longer to allow populating 1 token and avoid thundering herd
-				return 500 * time.Millisecond
+			if cycle == 5 {
+				// wait more than one refill period so a single token is restored,
+				// allowing cycle 6 through again
+				return 2100 * time.Millisecond
 			}
-			return 100 * time.Millisecond
+			// negligible refill while draining the bucket
+			return 10 * time.Millisecond
 		},
 		want: func(cycle int) bool {
-			return slices.Contains([]int{5, 6}, cycle)
+			// cycles 1-4 drain the bucket, cycle 5 finds it empty (thundering
+			// herd), and the refill wait lets cycle 6 through again
+			return cycle == 5
 		},
 	}}
 


### PR DESCRIPTION
Introduce a single-flight detector that coalesces every concurrent duplicate of a fingerprint from the first request, rather than only engaging above a burst threshold like the token bucket. Detection is always "on" and the existing gatekeeper handles the election, so exactly one request per fingerprint reaches the backend while the rest wait; pairing it with the Redis storage gives cross-process single-flight.

Also document when to reach for Anicetus versus CDN origin shielding, in-process singleflight, stale-while-revalidate, and XFetch, so users can tell whether the thundering herd scenario actually applies to them.

## Related Issue

None.

## Checklist

- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../blob/main/SECURITY.md).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [cadastros@rafael.net.br](mailto:cadastros@rafael.net.br)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

None.