### PR TITLE
Fix: Make gatekeeper election atomic and lease-bound (v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ import (
   "net/http"
   "time"
 
-  "github.com/rafaeljusto/anicetus/v2"
-  "github.com/rafaeljusto/anicetus/v2/detector"
-  "github.com/rafaeljusto/anicetus/v2/storage"
+  "github.com/rafaeljusto/anicetus/v3"
+  "github.com/rafaeljusto/anicetus/v3/detector"
+  "github.com/rafaeljusto/anicetus/v3/storage"
 )
 
 func main() {

--- a/anicetus_example_test.go
+++ b/anicetus_example_test.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/detector"
-	"github.com/rafaeljusto/anicetus/v2/storage"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/detector"
+	"github.com/rafaeljusto/anicetus/v3/storage"
 )
 
 // Request represents an incoming request.

--- a/anicetus_test.go
+++ b/anicetus_test.go
@@ -20,7 +20,7 @@ func TestAnicetus_Evaluate(t *testing.T) {
 			anicetus: false,
 		},
 		gatekeeperStorage: &fakeGatekeeperStorage{
-			exists:    false,
+			present:   false,
 			processed: false,
 		},
 		want: anicetus.StatusOpenGates,
@@ -31,7 +31,7 @@ func TestAnicetus_Evaluate(t *testing.T) {
 			anicetus: true,
 		},
 		gatekeeperStorage: &fakeGatekeeperStorage{
-			exists:    false,
+			present:   false,
 			processed: false,
 		},
 		want: anicetus.StatusProcess,
@@ -42,7 +42,7 @@ func TestAnicetus_Evaluate(t *testing.T) {
 			anicetus: true,
 		},
 		gatekeeperStorage: &fakeGatekeeperStorage{
-			exists:    true,
+			present:   true,
 			processed: false,
 		},
 		want: anicetus.StatusWait,
@@ -53,7 +53,7 @@ func TestAnicetus_Evaluate(t *testing.T) {
 			anicetus: true,
 		},
 		gatekeeperStorage: &fakeGatekeeperStorage{
-			exists:    true,
+			present:   true,
 			processed: true,
 		},
 		want: anicetus.StatusOpenGates,
@@ -64,7 +64,7 @@ func TestAnicetus_Evaluate(t *testing.T) {
 			anicetus: true,
 		},
 		gatekeeperStorage: &fakeGatekeeperStorage{
-			exists:    false,
+			present:   false,
 			processed: false,
 		},
 		want: anicetus.StatusOpenGates,
@@ -156,12 +156,16 @@ func (d fakeDetector) IsThunderingHerd(context.Context, anicetus.Fingerprint) (b
 
 // fakeGatekeeperStorage is a fake implementation of GatekeeperStorage.
 type fakeGatekeeperStorage struct {
-	exists    bool
+	present   bool
 	processed bool
 }
 
-func (gs fakeGatekeeperStorage) Exists(context.Context, anicetus.Fingerprint) (bool, error) {
-	return gs.exists, nil
+func (gs *fakeGatekeeperStorage) Add(context.Context, anicetus.Fingerprint) (bool, error) {
+	if gs.present {
+		return false, nil
+	}
+	gs.present = true
+	return true, nil
 }
 
 func (gs fakeGatekeeperStorage) Processed(context.Context, anicetus.Fingerprint) (bool, error) {
@@ -169,13 +173,13 @@ func (gs fakeGatekeeperStorage) Processed(context.Context, anicetus.Fingerprint)
 }
 
 func (gs *fakeGatekeeperStorage) Store(_ context.Context, _ anicetus.Fingerprint, processed bool) error {
-	gs.exists = true
+	gs.present = true
 	gs.processed = processed
 	return nil
 }
 
 func (gs *fakeGatekeeperStorage) Remove(context.Context, anicetus.Fingerprint) error {
-	gs.exists = false
+	gs.present = false
 	gs.processed = false
 	return nil
 }

--- a/anicetus_test.go
+++ b/anicetus_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rafaeljusto/anicetus/v2"
+	"github.com/rafaeljusto/anicetus/v3"
 )
 
 func TestAnicetus_Evaluate(t *testing.T) {

--- a/cmd/anicetus-http/main.go
+++ b/cmd/anicetus-http/main.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"time"
 
-	anicetushttp "github.com/rafaeljusto/anicetus/v2/internal/http"
+	anicetushttp "github.com/rafaeljusto/anicetus/v3/internal/http"
 )
 
 func main() {

--- a/detector/redigo/tokenbucket_redis.go
+++ b/detector/redigo/tokenbucket_redis.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/detector"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/detector"
 )
 
 var (

--- a/detector/redigo/tokenbucket_redis_test.go
+++ b/detector/redigo/tokenbucket_redis_test.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/detector"
-	"github.com/rafaeljusto/anicetus/v2/detector/redigo"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/detector"
+	"github.com/rafaeljusto/anicetus/v3/detector/redigo"
 )
 
 const defaultRedisAddress = "localhost:6379"

--- a/detector/singleflight_inmemory.go
+++ b/detector/singleflight_inmemory.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"context"
 
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/internal/mapexp"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/internal/mapexp"
 )
 
 var _ anicetus.Detector = &SingleFlightInMemory{}

--- a/detector/singleflight_inmemory_test.go
+++ b/detector/singleflight_inmemory_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/detector"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/detector"
 )
 
 func TestSingleFlightInMemory_IsThunderingHerd(t *testing.T) {

--- a/detector/tokenbucket_inmemory.go
+++ b/detector/tokenbucket_inmemory.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/internal/mapexp"
-	"github.com/rafaeljusto/anicetus/v2/internal/rate"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/internal/mapexp"
+	"github.com/rafaeljusto/anicetus/v3/internal/rate"
 )
 
 var _ anicetus.Detector = &TokenBucketInMemory{}

--- a/detector/tokenbucket_inmemory_test.go
+++ b/detector/tokenbucket_inmemory_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/detector"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/detector"
 )
 
 func TestTokenBucketInMemory_IsThunderingHerd(t *testing.T) {

--- a/fingerprint/http_request.go
+++ b/fingerprint/http_request.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/rafaeljusto/anicetus/v2"
+	"github.com/rafaeljusto/anicetus/v3"
 )
 
 var _ anicetus.Fingerprinter = &HTTPRequest{}

--- a/fingerprint/http_request_test.go
+++ b/fingerprint/http_request_test.go
@@ -9,8 +9,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/fingerprint"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/fingerprint"
 )
 
 func TestHTTPRequest_Fingerprint(t *testing.T) {

--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -20,25 +20,27 @@ func NewGatekeeper(storage GatekeeperStorage) *Gatekeeper {
 
 // analyze checks if the fingerprint is valid to be processed.
 func (g Gatekeeper) analyze(ctx context.Context, fingerprint Fingerprint) (Status, error) {
-	if exists, err := g.storage.Exists(ctx, fingerprint); err != nil {
-		return StatusFailed, fmt.Errorf("failed to check if fingerprint exists: %w", err)
-
-	} else if exists {
-		if processed, err := g.storage.Processed(ctx, fingerprint); err != nil {
-			return StatusFailed, fmt.Errorf("failed to get fingerprint processed flag: %w", err)
-
-		} else if processed {
-			return StatusOpenGates, nil
-		}
-
-		return StatusWait, nil
+	// Add is the atomic election: exactly one concurrent request with the same
+	// fingerprint gets elected == true and is allowed to reach the backend.
+	elected, err := g.storage.Add(ctx, fingerprint)
+	if err != nil {
+		return StatusFailed, fmt.Errorf("failed to elect fingerprint: %w", err)
+	}
+	if elected {
+		return StatusProcess, nil
 	}
 
-	if err := g.storage.Store(ctx, fingerprint, false); err != nil {
-		return StatusFailed, fmt.Errorf("failed to store fingerprint: %w", err)
+	// Another request was already elected. Let this one through only once the
+	// elected request has populated the backend cache, otherwise make it wait.
+	processed, err := g.storage.Processed(ctx, fingerprint)
+	if err != nil {
+		return StatusFailed, fmt.Errorf("failed to get fingerprint processed flag: %w", err)
+	}
+	if processed {
+		return StatusOpenGates, nil
 	}
 
-	return StatusProcess, nil
+	return StatusWait, nil
 }
 
 // Store stores the fingerprint in the storage. This should be called after the
@@ -55,11 +57,22 @@ func (g Gatekeeper) Remove(ctx context.Context, fingerprint Fingerprint) error {
 
 // GatekeeperStorage stores the fingerprints.
 type GatekeeperStorage interface {
-	// Exists checks if the fingerprint exists in the storage.
-	Exists(ctx context.Context, fingerprint Fingerprint) (bool, error)
+	// Add atomically records the fingerprint as in-flight (stored with the
+	// processed flag set to false) if it is not already present, returning true
+	// only when this call created the entry. For a group of concurrent requests
+	// with the same fingerprint, exactly one caller MUST receive true: that
+	// request is the one elected to reach the backend. This method is the
+	// election primitive and therefore MUST be atomic (check-and-set), otherwise
+	// a thundering herd can elect more than one request.
+	//
+	// The entry created by Add MUST expire after an implementation-defined lease.
+	// This guarantees that if the elected request dies before calling Store or
+	// Remove, the fingerprint is eventually released for a new election instead
+	// of blocking every subsequent request forever.
+	Add(ctx context.Context, fingerprint Fingerprint) (bool, error)
 	// Processed checks if the fingerprint has been processed.
 	Processed(ctx context.Context, fingerprint Fingerprint) (bool, error)
-	// Store stores the fingerprint in the storage.
+	// Store stores the fingerprint in the storage with the given processed flag.
 	Store(ctx context.Context, fingerprint Fingerprint, processed bool) error
 	// Remove removes the fingerprint from the storage. It MUST not return an
 	// error if the fingerprint doesn't exist.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rafaeljusto/anicetus/v2
+module github.com/rafaeljusto/anicetus/v3
 
 go 1.24
 

--- a/internal/http/config.go
+++ b/internal/http/config.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rafaeljusto/anicetus/v2/fingerprint"
+	"github.com/rafaeljusto/anicetus/v3/fingerprint"
 )
 
 // Config stores the configuration for the application.

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -4,8 +4,8 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/fingerprint"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/fingerprint"
 )
 
 // RegisterHandlers registers the handlers for the web server.

--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/rafaeljusto/anicetus/v2"
+	"github.com/rafaeljusto/anicetus/v3"
 )
 
 type forwardRequestOptions struct {

--- a/internal/http/resources.go
+++ b/internal/http/resources.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/detector"
-	"github.com/rafaeljusto/anicetus/v2/fingerprint"
-	"github.com/rafaeljusto/anicetus/v2/storage"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/detector"
+	"github.com/rafaeljusto/anicetus/v3/fingerprint"
+	"github.com/rafaeljusto/anicetus/v3/storage"
 )
 
 // Resources stores the resources for the web server.

--- a/storage/inmemory.go
+++ b/storage/inmemory.go
@@ -3,46 +3,116 @@ package storage
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/rafaeljusto/anicetus/v2"
 )
 
 var _ anicetus.GatekeeperStorage = &InMemory{}
 
+// inMemorySweepInterval is the number of mutating operations between opportunistic
+// sweeps of expired entries. It bounds memory without a background goroutine.
+const inMemorySweepInterval = 1024
+
+// inMemoryEntry is a stored fingerprint together with its lease expiration.
+type inMemoryEntry struct {
+	processed bool
+	expiresAt time.Time
+}
+
 // InMemory is an in-memory storage for the fingerprints.
 type InMemory struct {
-	// data is the data stored in the storage.
-	data sync.Map
+	// mu guards data and opsSinceSweep, making the check-and-set in Add atomic.
+	mu   sync.Mutex
+	data map[anicetus.Fingerprint]inMemoryEntry
+	// leaseTTL is how long an entry is held before it is considered expired.
+	leaseTTL time.Duration
+	// opsSinceSweep counts mutating operations since the last expiry sweep.
+	opsSinceSweep int
 }
 
 // NewInMemory creates a new in-memory storage.
-func NewInMemory() *InMemory {
-	return &InMemory{}
+func NewInMemory(options ...Option) *InMemory {
+	o := NewOptions()
+	for _, opt := range options {
+		opt(o)
+	}
+
+	return &InMemory{
+		data:     make(map[anicetus.Fingerprint]inMemoryEntry),
+		leaseTTL: o.LeaseTTL(),
+	}
 }
 
-// Exists checks if the fingerprint exists in the storage.
-func (s *InMemory) Exists(_ context.Context, fingerprint anicetus.Fingerprint) (bool, error) {
-	_, ok := s.data.Load(fingerprint)
-	return ok, nil
+// Add atomically records the fingerprint as in-flight if it is not already
+// present (and unexpired), returning true only for the caller that created the
+// entry. This is the election primitive: under a thundering herd exactly one
+// concurrent caller receives true.
+func (s *InMemory) Add(_ context.Context, fingerprint anicetus.Fingerprint) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	if e, ok := s.data[fingerprint]; ok && now.Before(e.expiresAt) {
+		return false, nil
+	}
+
+	s.data[fingerprint] = inMemoryEntry{
+		processed: false,
+		expiresAt: now.Add(s.leaseTTL),
+	}
+	s.sweep(now)
+	return true, nil
 }
 
 // Processed checks if the fingerprint was processed.
 func (s *InMemory) Processed(_ context.Context, fingerprint anicetus.Fingerprint) (bool, error) {
-	data, ok := s.data.Load(fingerprint)
-	if !ok {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e, ok := s.data[fingerprint]
+	if !ok || !time.Now().Before(e.expiresAt) {
 		return false, nil
 	}
-	return data.(bool), nil
+	return e.processed, nil
 }
 
-// Store stores the fingerprint in the storage.
+// Store stores the fingerprint in the storage, refreshing its lease.
 func (s *InMemory) Store(_ context.Context, fingerprint anicetus.Fingerprint, processed bool) error {
-	s.data.Store(fingerprint, processed)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	s.data[fingerprint] = inMemoryEntry{
+		processed: processed,
+		expiresAt: now.Add(s.leaseTTL),
+	}
+	s.sweep(now)
 	return nil
 }
 
 // Remove removes the fingerprint from the storage.
 func (s *InMemory) Remove(_ context.Context, fingerprint anicetus.Fingerprint) error {
-	s.data.Delete(fingerprint)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.data, fingerprint)
 	return nil
+}
+
+// sweep opportunistically deletes expired entries. The caller MUST hold s.mu.
+// It runs at most once every inMemorySweepInterval mutating operations, so the
+// amortized cost is negligible while keeping the map bounded to live entries.
+func (s *InMemory) sweep(now time.Time) {
+	s.opsSinceSweep++
+	if s.opsSinceSweep < inMemorySweepInterval {
+		return
+	}
+	s.opsSinceSweep = 0
+
+	for fingerprint, e := range s.data {
+		if !now.Before(e.expiresAt) {
+			delete(s.data, fingerprint)
+		}
+	}
 }

--- a/storage/inmemory.go
+++ b/storage/inmemory.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rafaeljusto/anicetus/v2"
+	"github.com/rafaeljusto/anicetus/v3"
 )
 
 var _ anicetus.GatekeeperStorage = &InMemory{}

--- a/storage/inmemory_test.go
+++ b/storage/inmemory_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/storage"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/storage"
 )
 
 func TestInMemory_lifecycle(t *testing.T) {

--- a/storage/inmemory_test.go
+++ b/storage/inmemory_test.go
@@ -1,7 +1,9 @@
 package storage_test
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/rafaeljusto/anicetus/v2"
 	"github.com/rafaeljusto/anicetus/v2/storage"
@@ -10,52 +12,121 @@ import (
 func TestInMemory_lifecycle(t *testing.T) {
 	fingerprint := anicetus.Fingerprint("test")
 
-	storage := storage.NewInMemory()
-	if ok, err := storage.Exists(t.Context(), fingerprint); err != nil {
+	s := storage.NewInMemory()
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	} else if !elected {
+		t.Error("first Add should elect the fingerprint")
+	}
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	} else if elected {
+		t.Error("second Add should not elect the fingerprint")
+	}
+
+	if ok, err := s.Processed(t.Context(), fingerprint); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else if ok {
-		t.Error("unexpected fingerprint exists")
+		t.Error("fingerprint should not be processed yet")
 	}
 
-	if ok, err := storage.Processed(t.Context(), fingerprint); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	} else if ok {
-		t.Error("unexpected fingerprint processed")
-	}
-
-	if err := storage.Store(t.Context(), fingerprint, false); err != nil {
+	if err := s.Store(t.Context(), fingerprint, true); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if ok, err := storage.Exists(t.Context(), fingerprint); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	} else if !ok {
-		t.Error("fingerprint should exists")
-	}
-
-	if ok, err := storage.Processed(t.Context(), fingerprint); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	} else if ok {
-		t.Error("fingerprint should not be processed")
-	}
-
-	if err := storage.Store(t.Context(), fingerprint, true); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if ok, err := storage.Processed(t.Context(), fingerprint); err != nil {
+	if ok, err := s.Processed(t.Context(), fingerprint); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else if !ok {
 		t.Error("fingerprint should be processed")
 	}
 
-	if err := storage.Remove(t.Context(), fingerprint); err != nil {
+	if err := s.Remove(t.Context(), fingerprint); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if ok, err := storage.Exists(t.Context(), fingerprint); err != nil {
+	if ok, err := s.Processed(t.Context(), fingerprint); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else if ok {
-		t.Error("fingerprint should not exists")
+		t.Error("fingerprint should not be processed after removal")
+	}
+
+	// After removal the fingerprint is available for a new election.
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	} else if !elected {
+		t.Error("Add after Remove should elect the fingerprint again")
+	}
+}
+
+// TestInMemory_Add_concurrent is the regression test for the election race: no
+// matter how many goroutines call Add for the same fingerprint at once, exactly
+// one must be elected.
+func TestInMemory_Add_concurrent(t *testing.T) {
+	const goroutines = 512
+
+	s := storage.NewInMemory()
+	fingerprint := anicetus.Fingerprint("test")
+
+	var (
+		wg      sync.WaitGroup
+		start   = make(chan struct{})
+		elected int64
+		mu      sync.Mutex
+	)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			ok, err := s.Add(t.Context(), fingerprint)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if ok {
+				mu.Lock()
+				elected++
+				mu.Unlock()
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	if elected != 1 {
+		t.Errorf("expected exactly 1 elected request, got %d", elected)
+	}
+}
+
+// TestInMemory_Add_leaseExpiry ensures a fingerprint whose lease expired (e.g.
+// its elected request crashed without cleaning up) is released for a new
+// election instead of blocking forever.
+func TestInMemory_Add_leaseExpiry(t *testing.T) {
+	lease := 50 * time.Millisecond
+
+	s := storage.NewInMemory(storage.WithLeaseTTL(lease))
+	fingerprint := anicetus.Fingerprint("test")
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !elected {
+		t.Fatal("first Add should elect the fingerprint")
+	}
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if elected {
+		t.Fatal("Add within the lease should not elect the fingerprint")
+	}
+
+	time.Sleep(2 * lease)
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !elected {
+		t.Error("Add after the lease expired should elect the fingerprint again")
 	}
 }

--- a/storage/options.go
+++ b/storage/options.go
@@ -1,21 +1,39 @@
 package storage
 
-import "log/slog"
+import (
+	"log/slog"
+	"time"
+)
+
+// defaultLeaseTTL is the default duration an elected (in-flight) fingerprint is
+// held before it is considered stale and released for a new election. It should
+// comfortably exceed the backend processing time so a slow-but-alive request is
+// not evicted, while being short enough to recover quickly from a crashed one.
+const defaultLeaseTTL = 30 * time.Second
 
 // Options provides all the available options.
 type Options struct {
 	// logger to be used internally.
 	logger *slog.Logger
+	// leaseTTL is how long an elected fingerprint is held before expiring.
+	leaseTTL time.Duration
 }
 
 // NewOptions creates a new Options with default values.
 func NewOptions() *Options {
-	return &Options{}
+	return &Options{
+		leaseTTL: defaultLeaseTTL,
+	}
 }
 
 // Logger returns the logger to be used internally.
 func (o *Options) Logger() *slog.Logger {
 	return o.logger
+}
+
+// LeaseTTL returns the lease duration for an elected fingerprint.
+func (o *Options) LeaseTTL() time.Duration {
+	return o.leaseTTL
 }
 
 // Option is a helper function to configure the storage.
@@ -25,5 +43,16 @@ type Option func(*Options)
 func WithLogger(logger *slog.Logger) Option {
 	return func(o *Options) {
 		o.logger = logger
+	}
+}
+
+// WithLeaseTTL sets how long an elected fingerprint is held before it expires
+// and becomes available for a new election. Set it above the expected backend
+// processing time to avoid electing a second request while the first is still
+// running, and below the point where a crashed request would block the
+// fingerprint for an unacceptable amount of time.
+func WithLeaseTTL(ttl time.Duration) Option {
+	return func(o *Options) {
+		o.leaseTTL = ttl
 	}
 }

--- a/storage/redigo/redis.go
+++ b/storage/redigo/redis.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/storage"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/storage"
 )
 
 var _ anicetus.GatekeeperStorage = &Redis{}

--- a/storage/redigo/redis.go
+++ b/storage/redigo/redis.go
@@ -2,8 +2,10 @@ package redigo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/rafaeljusto/anicetus/v2"
@@ -12,10 +14,16 @@ import (
 
 var _ anicetus.GatekeeperStorage = &Redis{}
 
+// keyPrefix namespaces the gatekeeper keys so they cannot collide with keys
+// owned by other components sharing the same Redis database (e.g. the detector,
+// which uses its own "anicetus:th:" and "anicetus:cooldown:" prefixes).
+const keyPrefix = "anicetus:gk:"
+
 // Redis is a redis storage for the fingerprints.
 type Redis struct {
-	pool   *redis.Pool
-	logger *slog.Logger
+	pool     *redis.Pool
+	logger   *slog.Logger
+	leaseTTL time.Duration
 }
 
 // NewRedis creates a new redis storage.
@@ -26,30 +34,32 @@ func NewRedis(pool *redis.Pool, options ...storage.Option) *Redis {
 	}
 
 	return &Redis{
-		pool:   pool,
-		logger: o.Logger(),
+		pool:     pool,
+		logger:   o.Logger(),
+		leaseTTL: o.LeaseTTL(),
 	}
 }
 
-// Exists checks if the fingerprint exists in the storage.
-func (r *Redis) Exists(ctx context.Context, fingerprint anicetus.Fingerprint) (bool, error) {
+// Add atomically records the fingerprint as in-flight if it is not already
+// present, returning true only for the caller that created the entry. It relies
+// on Redis' atomic "SET key value NX PX ttl": NX makes the write conditional on
+// absence (the election), while PX attaches the lease so a crashed elected
+// request cannot block the fingerprint forever.
+func (r *Redis) Add(ctx context.Context, fingerprint anicetus.Fingerprint) (bool, error) {
 	conn, err := r.pool.GetContext(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to get redis connection: %w", err)
 	}
-	defer func() {
-		if err := conn.Close(); err != nil {
-			if r.logger != nil {
-				r.logger.Error("failed to close redis connection", slog.String("error", err.Error()))
-			}
-		}
-	}()
+	defer r.close(conn)
 
-	result, err := redis.Int(conn.Do("EXISTS", fingerprint))
-	if err != nil {
-		return false, fmt.Errorf("failed to check redis key: %w", err)
+	result, err := redis.String(conn.Do("SET", key(fingerprint), 0, "NX", "PX", r.leaseMillis()))
+	if errors.Is(err, redis.ErrNil) {
+		// NX prevented the write: the fingerprint was already elected.
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("failed to set redis key: %w", err)
 	}
-	return result == 1, nil
+	return result == "OK", nil
 }
 
 // Processed checks if the fingerprint was processed.
@@ -58,16 +68,10 @@ func (r *Redis) Processed(ctx context.Context, fingerprint anicetus.Fingerprint)
 	if err != nil {
 		return false, fmt.Errorf("failed to get redis connection: %w", err)
 	}
-	defer func() {
-		if err := conn.Close(); err != nil {
-			if r.logger != nil {
-				r.logger.Error("failed to close redis connection", slog.String("error", err.Error()))
-			}
-		}
-	}()
+	defer r.close(conn)
 
-	result, err := redis.Bool(conn.Do("GET", fingerprint))
-	if err == redis.ErrNil {
+	result, err := redis.Bool(conn.Do("GET", key(fingerprint)))
+	if errors.Is(err, redis.ErrNil) {
 		return false, nil
 	} else if err != nil {
 		return false, fmt.Errorf("failed to get redis key: %w", err)
@@ -75,21 +79,15 @@ func (r *Redis) Processed(ctx context.Context, fingerprint anicetus.Fingerprint)
 	return result, nil
 }
 
-// Store stores the fingerprint in the storage.
+// Store stores the fingerprint in the storage, refreshing its lease.
 func (r *Redis) Store(ctx context.Context, fingerprint anicetus.Fingerprint, processed bool) error {
 	conn, err := r.pool.GetContext(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get redis connection: %w", err)
 	}
-	defer func() {
-		if err := conn.Close(); err != nil {
-			if r.logger != nil {
-				r.logger.Error("failed to close redis connection", slog.String("error", err.Error()))
-			}
-		}
-	}()
+	defer r.close(conn)
 
-	result, err := redis.String(conn.Do("SET", fingerprint, boolToInt(processed)))
+	result, err := redis.String(conn.Do("SET", key(fingerprint), boolToInt(processed), "PX", r.leaseMillis()))
 	if err != nil {
 		return fmt.Errorf("failed to set redis key: %w", err)
 	}
@@ -105,19 +103,36 @@ func (r *Redis) Remove(ctx context.Context, fingerprint anicetus.Fingerprint) er
 	if err != nil {
 		return fmt.Errorf("failed to get redis connection: %w", err)
 	}
-	defer func() {
-		if err := conn.Close(); err != nil {
-			if r.logger != nil {
-				r.logger.Error("failed to close redis connection", slog.String("error", err.Error()))
-			}
-		}
-	}()
+	defer r.close(conn)
 
-	_, err = redis.Int(conn.Do("DEL", fingerprint))
+	_, err = redis.Int(conn.Do("DEL", key(fingerprint)))
 	if err != nil {
 		return fmt.Errorf("failed to delete redis key: %w", err)
 	}
 	return nil
+}
+
+// leaseMillis returns the lease duration in milliseconds, clamped to at least 1
+// so the PX argument is always valid.
+func (r *Redis) leaseMillis() int64 {
+	if ms := r.leaseTTL.Milliseconds(); ms > 0 {
+		return ms
+	}
+	return 1
+}
+
+// close returns the connection to the pool, logging any error.
+func (r *Redis) close(conn redis.Conn) {
+	if err := conn.Close(); err != nil {
+		if r.logger != nil {
+			r.logger.Error("failed to close redis connection", slog.String("error", err.Error()))
+		}
+	}
+}
+
+// key namespaces a fingerprint into the gatekeeper key space.
+func key(fingerprint anicetus.Fingerprint) string {
+	return keyPrefix + string(fingerprint)
 }
 
 func boolToInt(b bool) int {

--- a/storage/redigo/redis_test.go
+++ b/storage/redigo/redis_test.go
@@ -7,16 +7,18 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/rafaeljusto/anicetus/v2"
+	"github.com/rafaeljusto/anicetus/v2/storage"
 	"github.com/rafaeljusto/anicetus/v2/storage/redigo"
 )
 
 const defaultRedisAddress = "localhost:6379"
 
-func TestRedis_lifecycle(t *testing.T) {
-	fingerprint := anicetus.Fingerprint("test")
+func newRedisPool(t *testing.T) *redis.Pool {
+	t.Helper()
 
 	redisAddress := defaultRedisAddress
 	if e := os.Getenv("REDIS_ADDRESS"); e != "" {
@@ -38,57 +40,89 @@ func TestRedis_lifecycle(t *testing.T) {
 			t.Errorf("failed to close redis connection: %v", err)
 		}
 	}()
-	_, err = redisConn.Do("FLUSHDB")
-	if err != nil {
+	if _, err := redisConn.Do("FLUSHDB"); err != nil {
 		t.Fatalf("failed to flush redis database: %v", err)
 	}
 
-	storage := redigo.NewRedis(redisPool)
-	if ok, err := storage.Exists(t.Context(), fingerprint); err != nil {
+	return redisPool
+}
+
+func TestRedis_lifecycle(t *testing.T) {
+	fingerprint := anicetus.Fingerprint("test")
+
+	s := redigo.NewRedis(newRedisPool(t))
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	} else if !elected {
+		t.Error("first Add should elect the fingerprint")
+	}
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	} else if elected {
+		t.Error("second Add should not elect the fingerprint")
+	}
+
+	if ok, err := s.Processed(t.Context(), fingerprint); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else if ok {
-		t.Error("unexpected fingerprint exists")
+		t.Error("fingerprint should not be processed yet")
 	}
 
-	if ok, err := storage.Processed(t.Context(), fingerprint); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	} else if ok {
-		t.Error("unexpected fingerprint processed")
-	}
-
-	if err := storage.Store(t.Context(), fingerprint, false); err != nil {
+	if err := s.Store(t.Context(), fingerprint, true); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if ok, err := storage.Exists(t.Context(), fingerprint); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	} else if !ok {
-		t.Error("fingerprint should exists")
-	}
-
-	if ok, err := storage.Processed(t.Context(), fingerprint); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	} else if ok {
-		t.Error("fingerprint should not be processed")
-	}
-
-	if err := storage.Store(t.Context(), fingerprint, true); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if ok, err := storage.Processed(t.Context(), fingerprint); err != nil {
+	if ok, err := s.Processed(t.Context(), fingerprint); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else if !ok {
 		t.Error("fingerprint should be processed")
 	}
 
-	if err := storage.Remove(t.Context(), fingerprint); err != nil {
+	if err := s.Remove(t.Context(), fingerprint); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if ok, err := storage.Exists(t.Context(), fingerprint); err != nil {
+	if ok, err := s.Processed(t.Context(), fingerprint); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else if ok {
-		t.Error("fingerprint should not exists")
+		t.Error("fingerprint should not be processed after removal")
+	}
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	} else if !elected {
+		t.Error("Add after Remove should elect the fingerprint again")
+	}
+}
+
+// TestRedis_Add_leaseExpiry ensures the lease attached by Add releases the
+// fingerprint once it expires, so a crashed elected request cannot block it
+// forever.
+func TestRedis_Add_leaseExpiry(t *testing.T) {
+	lease := 200 * time.Millisecond
+
+	s := redigo.NewRedis(newRedisPool(t), storage.WithLeaseTTL(lease))
+	fingerprint := anicetus.Fingerprint("test")
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !elected {
+		t.Fatal("first Add should elect the fingerprint")
+	}
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if elected {
+		t.Fatal("Add within the lease should not elect the fingerprint")
+	}
+
+	time.Sleep(2 * lease)
+
+	if elected, err := s.Add(t.Context(), fingerprint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !elected {
+		t.Error("Add after the lease expired should elect the fingerprint again")
 	}
 }

--- a/storage/redigo/redis_test.go
+++ b/storage/redigo/redis_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
-	"github.com/rafaeljusto/anicetus/v2"
-	"github.com/rafaeljusto/anicetus/v2/storage"
-	"github.com/rafaeljusto/anicetus/v2/storage/redigo"
+	"github.com/rafaeljusto/anicetus/v3"
+	"github.com/rafaeljusto/anicetus/v3/storage"
+	"github.com/rafaeljusto/anicetus/v3/storage/redigo"
 )
 
 const defaultRedisAddress = "localhost:6379"


### PR DESCRIPTION
## Summary

Fixes the core correctness guarantee of the library: that **exactly one** request per fingerprint reaches the backend during a thundering herd. Along the way, hardens the failure mode where a crashed request could wedge a fingerprint forever, and bumps the module to `v3` for the breaking interface change.

## Problems

1. **Non-atomic election (critical).** `Gatekeeper.analyze` elected the request via `Exists()` then `Store()` as two separate calls. Under an actual thundering herd — the exact condition this library targets — many concurrent requests for the same fingerprint could all observe "not present" and all get elected, so more than one request hit the backend and the central guarantee did not hold.
2. **No lease → a dead leader wedges a fingerprint forever.** Both storages persisted the elected entry with no expiry. If the elected request crashed before `RequestDone`/`Cleanup`, every subsequent request for that fingerprint returned `StatusWait` indefinitely.
3. **Redis gatekeeper keys weren't namespaced**, risking collisions with the detector's keys in a shared database.

## Changes

- Replace `GatekeeperStorage.Exists` with an atomic **`Add(fingerprint) (bool, error)`** election primitive:
  - **InMemory** — check-and-set under a mutex.
  - **Redis** — `SET key val NX PX ttl`, atomic server-side.
- Every elected entry now carries a **lease** (`WithLeaseTTL`, default 30s). If the leader dies, the entry expires and the fingerprint is re-electable. InMemory expires lazily and sweeps opportunistically (no background goroutine); Redis relies on the `PX` expiry.
- Namespace Redis gatekeeper keys under `anicetus:gk:`.
- **Bump module path to `/v3`** (semantic import versioning) since `Exists` → `Add` is a breaking change.

## Tests

- `TestInMemory_Add_concurrent` — 512 goroutines race on the same fingerprint; asserts exactly one is elected (regression guard for problem #1).
- `*_leaseExpiry` tests in both backends — a fingerprint is released once its lease expires.
- Full suite passes with `-race` **and** `-tags=integration_tests` against a live Redis.

## Breaking change

`GatekeeperStorage.Exists` is replaced by `Add`. Custom storage implementations must implement atomic `Add` with a lease. Requires tagging the release **`v3.0.0`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)