### PR TITLE
Fix: Request handling and in-memory expiry lifecycle bugs

### DIFF
--- a/cmd/anicetus-http/main.go
+++ b/cmd/anicetus-http/main.go
@@ -79,6 +79,11 @@ func main() {
 			slog.String("error", err.Error()),
 		)
 	}
+	if err := resources.Close(); err != nil {
+		resources.Logger.Error("failed to release resources",
+			slog.String("error", err.Error()),
+		)
+	}
 	resources.Logger.Info("server stopped")
 }
 

--- a/detector/singleflight_inmemory.go
+++ b/detector/singleflight_inmemory.go
@@ -45,6 +45,13 @@ func NewSingleFlightInMemory(options ...SingleFlightOption) *SingleFlightInMemor
 	}
 }
 
+// Close stops the background goroutine used to expire the internal state. It is
+// safe to call more than once.
+func (s *SingleFlightInMemory) Close() error {
+	s.cooldowns.Stop()
+	return nil
+}
+
 // CoolDown will cool down the fingerprint.
 func (s *SingleFlightInMemory) CoolDown(_ context.Context, fingerprint anicetus.Fingerprint) error {
 	s.cooldowns.Set(fingerprint, true)

--- a/detector/tokenbucket_inmemory.go
+++ b/detector/tokenbucket_inmemory.go
@@ -37,6 +37,14 @@ func NewTokenBucketInMemory(options ...TokenBucketOption) *TokenBucketInMemory {
 	}
 }
 
+// Close stops the background goroutines used to expire the internal state. It
+// is safe to call more than once.
+func (t *TokenBucketInMemory) Close() error {
+	t.cooldowns.Stop()
+	t.limiters.Stop()
+	return nil
+}
+
 // CoolDown will cool down the fingerprint.
 func (t *TokenBucketInMemory) CoolDown(_ context.Context, fingerprint anicetus.Fingerprint) error {
 	t.cooldowns.Set(fingerprint, true)

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -21,12 +21,16 @@ func anicetusHandler(config *Config, resources *Resources) http.HandlerFunc {
 		)
 
 		if r.Method != http.MethodGet {
+			// Only GET requests are subject to thundering herd control; anything
+			// else is forwarded straight to the backend. Return afterwards so the
+			// request is not evaluated and forwarded a second time.
 			if err := forwardRequest(w, r, config, resources); err != nil {
 				httpLogger.Error("failed to forward request",
 					slog.String("error", err.Error()),
 				)
 				w.WriteHeader(http.StatusInternalServerError)
 			}
+			return
 		}
 
 		fingerprint := fingerprint.NewHTTPRequest(r,

--- a/internal/http/handlers_test.go
+++ b/internal/http/handlers_test.go
@@ -1,0 +1,84 @@
+package http
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rafaeljusto/anicetus/v3/fingerprint"
+)
+
+// newTestHandler wires a handler in front of a backend that counts how many
+// times it is hit.
+func newTestHandler(t *testing.T) (http.HandlerFunc, *atomic.Int64) {
+	t.Helper()
+
+	var backendHits atomic.Int64
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		backendHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(backend.Close)
+
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("failed to parse backend url: %v", err)
+	}
+
+	config := &Config{}
+	config.LoggerLevel = slog.LevelError
+	config.Detector.RequestsPerMinute = 1000
+	config.Detector.CoolDown = time.Minute
+	config.Backend.Timeout = time.Minute
+	config.Backend.Address = backendURL
+	config.Fingerprint.Fields = []fingerprint.HTTPRequestField{
+		fingerprint.HTTPRequestFieldMethod,
+		fingerprint.HTTPRequestFieldPath,
+	}
+
+	resources := NewResources(config)
+	t.Cleanup(func() { _ = resources.Close() })
+
+	return anicetusHandler(config, resources), &backendHits
+}
+
+// TestAnicetusHandler_forwardsNonGetOnce is the regression test for the missing
+// return that caused non-GET requests to be forwarded to the backend twice.
+func TestAnicetusHandler_forwardsNonGetOnce(t *testing.T) {
+	handler, backendHits := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/resource", strings.NewReader("body"))
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	if got := backendHits.Load(); got != 1 {
+		t.Errorf("expected backend to be hit once for POST, got %d", got)
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+}
+
+// TestAnicetusHandler_forwardsGetOnce guards the normal (open gates) path so the
+// return added for non-GET requests does not accidentally short-circuit GETs.
+func TestAnicetusHandler_forwardsGetOnce(t *testing.T) {
+	handler, backendHits := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/resource", nil)
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	if got := backendHits.Load(); got != 1 {
+		t.Errorf("expected backend to be hit once for GET, got %d", got)
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+}

--- a/internal/http/resources.go
+++ b/internal/http/resources.go
@@ -17,22 +17,28 @@ type Resources struct {
 	Logger        *slog.Logger
 	Anicetus      *anicetus.Anicetus[fingerprint.HTTPRequest]
 	BackendClient *http.Client
+
+	// detector is retained so its background goroutines can be stopped on Close.
+	detector *detector.TokenBucketInMemory
 }
 
 // NewResources creates a new set of resources for the web server.
 func NewResources(config *Config) *Resources {
+	tokenBucket := detector.NewTokenBucketInMemory(
+		detector.TokenBucketWithLimitersBurst(config.Detector.RequestsPerMinute),
+		detector.TokenBucketWithLimitersInterval(time.Minute),
+		detector.TokenBucketWithCoolDownInterval(config.Detector.CoolDown),
+	)
+
 	resources := &Resources{
 		Logger: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			Level: config.LoggerLevel,
 		})),
 		Anicetus: anicetus.NewAnicetus[fingerprint.HTTPRequest](
-			detector.NewTokenBucketInMemory(
-				detector.TokenBucketWithLimitersBurst(config.Detector.RequestsPerMinute),
-				detector.TokenBucketWithLimitersInterval(time.Minute),
-				detector.TokenBucketWithCoolDownInterval(config.Detector.CoolDown),
-			),
+			tokenBucket,
 			storage.NewInMemory(),
 		),
+		detector: tokenBucket,
 	}
 
 	resources.BackendClient = &http.Client{
@@ -40,4 +46,10 @@ func NewResources(config *Config) *Resources {
 	}
 
 	return resources
+}
+
+// Close releases the resources held by the web server, stopping the detector's
+// background goroutines.
+func (r *Resources) Close() error {
+	return r.detector.Close()
 }

--- a/internal/mapexp/expiration_queue.go
+++ b/internal/mapexp/expiration_queue.go
@@ -45,7 +45,15 @@ func (e *expirationQueue[K]) renew(key K) {
 
 	for i, item := range e.items {
 		if item.key == key {
-			e.items[i].expiration = time.Now().Add(e.ttl)
+			// Move the item to the back with a fresh expiration. purge relies on
+			// the queue staying ordered by ascending expiration; updating the
+			// expiration in place would leave a longer-lived item ahead of
+			// shorter-lived ones and make purge stop scanning too early.
+			e.items = append(e.items[:i], e.items[i+1:]...)
+			e.items = append(e.items, expirationQueueItem[K]{
+				key:        key,
+				expiration: time.Now().Add(e.ttl),
+			})
 			break
 		}
 	}

--- a/internal/mapexp/map.go
+++ b/internal/mapexp/map.go
@@ -11,7 +11,8 @@ type Map[K comparable, V any] struct {
 	itemsMutex      sync.RWMutex
 	expirationQueue *expirationQueue[K]
 
-	stop chan struct{}
+	stop     chan struct{}
+	stopOnce sync.Once
 }
 
 // New creates a new Map.
@@ -19,6 +20,7 @@ func New[K comparable, V any](ttl time.Duration) *Map[K, V] {
 	m := &Map[K, V]{
 		items:           make(map[K]V),
 		expirationQueue: newExpirationQueue[K](ttl),
+		stop:            make(chan struct{}),
 	}
 	m.start()
 	return m
@@ -73,7 +75,10 @@ func (m *Map[K, V]) start() {
 	}()
 }
 
-// Stop stops the map from expiring the keys.
+// Stop stops the background goroutine that expires the keys. It is safe to call
+// more than once.
 func (m *Map[K, V]) Stop() {
-	close(m.stop)
+	m.stopOnce.Do(func() {
+		close(m.stop)
+	})
 }

--- a/internal/mapexp/mapexp_test.go
+++ b/internal/mapexp/mapexp_test.go
@@ -1,0 +1,42 @@
+package mapexp
+
+import (
+	"testing"
+	"time"
+)
+
+// TestExpirationQueue_renewKeepsOrder is the regression test for renew breaking
+// the ascending-expiration ordering that purge relies on. After a stale item is
+// renewed it must move behind the still-expired items, otherwise purge stops
+// scanning at the renewed item and never reclaims the expired ones.
+func TestExpirationQueue_renewKeepsOrder(t *testing.T) {
+	ttl := 200 * time.Millisecond
+	q := newExpirationQueue[string](ttl)
+
+	q.add("a")
+	q.add("b")
+
+	// Let both entries expire, then renew "a" so it is no longer expired while
+	// "b" still is.
+	time.Sleep(2 * ttl)
+	q.renew("a")
+
+	expired := q.purge()
+
+	if len(expired) != 1 || expired[0] != "b" {
+		t.Fatalf("expected purge to reclaim only [b], got %v", expired)
+	}
+
+	// "a" must still be queued (its lease was renewed).
+	if len(q.items) != 1 || q.items[0].key != "a" {
+		t.Fatalf("expected [a] to remain queued, got %v", q.items)
+	}
+}
+
+func TestMap_StopIsIdempotent(t *testing.T) {
+	m := New[string, int](time.Minute)
+
+	// Must not panic, even when called more than once.
+	m.Stop()
+	m.Stop()
+}

--- a/internal/mapexp/mapexp_test.go
+++ b/internal/mapexp/mapexp_test.go
@@ -33,7 +33,7 @@ func TestExpirationQueue_renewKeepsOrder(t *testing.T) {
 	}
 }
 
-func TestMap_StopIsIdempotent(t *testing.T) {
+func TestMap_StopIsIdempotent(*testing.T) {
 	m := New[string, int](time.Minute)
 
 	// Must not panic, even when called more than once.

--- a/storage/redigo/redis_test.go
+++ b/storage/redigo/redis_test.go
@@ -26,6 +26,9 @@ func newRedisPool(t *testing.T) *redis.Pool {
 	}
 
 	redisPool := &redis.Pool{
+		MaxIdle:     10,
+		MaxActive:   100,
+		IdleTimeout: 5 * time.Minute,
 		DialContext: func(ctx context.Context) (redis.Conn, error) {
 			return redis.DialContext(ctx, "tcp", redisAddress)
 		},
@@ -101,7 +104,10 @@ func TestRedis_lifecycle(t *testing.T) {
 // fingerprint once it expires, so a crashed elected request cannot block it
 // forever.
 func TestRedis_Add_leaseExpiry(t *testing.T) {
-	lease := 200 * time.Millisecond
+	// The lease must comfortably exceed the round-trip of a couple of commands
+	// so the "within lease" Add reliably observes the key, while remaining short
+	// enough to keep the test fast once we wait it out.
+	lease := 2 * time.Second
 
 	s := redigo.NewRedis(newRedisPool(t), storage.WithLeaseTTL(lease))
 	fingerprint := anicetus.Fingerprint("test")


### PR DESCRIPTION
## Summary

Three independent correctness bugs found during review, each with a regression test.

### 1. Non-GET requests were forwarded to the backend twice
The non-GET branch in `anicetusHandler` forwarded the request but didn't `return`, so it fell through and was fingerprinted, evaluated, and forwarded a **second** time. Added the missing `return`.

### 2. `mapexp.Map` leaked its goroutine and `Stop()` panicked
The `stop` channel was never initialized, so `Stop()` did `close(nil)` (panic) and the janitor goroutine could never be signalled to exit — every detector leaked its expiry goroutines. Initialized the channel, made `Stop()` idempotent (`sync.Once`), and exposed `Close()` on the in-memory detectors, wired into the HTTP service shutdown so the goroutines are actually reclaimed.

### 3. `expirationQueue.renew` broke the ordering `purge` relies on
`purge` stops at the first unexpired entry (the queue is meant to stay ordered by ascending expiration). `renew` updated an entry's expiration **in place**, leaving a longer-lived entry ahead of shorter-lived ones, so `purge` would stop early and never reclaim the expired entries behind it. `renew` now moves the entry to the back.

## Tests

- `internal/http`: handler forwards a non-GET (and a GET) to a counting backend **exactly once** — regression guard for #1.
- `internal/mapexp`: `renew` keeps queue order so `purge` reclaims the right entry (#3); `Map.Stop` is idempotent / does not panic (#2).
- Gave the Redis integration test pool connection reuse (`MaxIdle`) and a lease margin that tolerates client round-trip latency.

## Verification

`go vet` clean, `gofmt` clean. Full unit suite passes and is **race-clean** (`go test -race ./...`). `storage/redigo` integration passes against a live Redis; the `detector/redigo` wall-clock token-bucket test is unchanged and continues to rely on CI's Redis (a network agent on my local machine adds ~300ms per round-trip, which only that timing-coupled test is sensitive to).

## Notes

- No API breaking changes. `Close()` on the in-memory detectors and `Resources` is additive.
- Commit is unsigned (GPG can't prompt in my environment); re-sign before merge if branch protection requires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)