### PR TITLE
Feature: Configurable wait for blocked requests

### DIFF
--- a/cmd/anicetus-http/README.md
+++ b/cmd/anicetus-http/README.md
@@ -34,3 +34,5 @@ The following environment variables can be used to configure the server:
 | `ANICETUS_FINGERPRINT_HEADERS`          | HTTP headers that are part of the fingerprint |
 | `ANICETUS_LOG_LEVEL`                    | Log level                                     |
 | `ANICETUS_PORT`                         | HTTP port to listen                           |
+| `ANICETUS_WAIT_POLL_INTERVAL`           | Gatekeeper re-check interval while waiting    |
+| `ANICETUS_WAIT_TIMEOUT`                 | Time a blocked request is held (0 = no wait)  |

--- a/internal/http/config.go
+++ b/internal/http/config.go
@@ -30,6 +30,14 @@ type Config struct {
 		Timeout time.Duration
 		Address *url.URL
 	}
+	Wait struct {
+		// Timeout is how long a blocked request is held waiting for the elected
+		// request to finish before giving up. Zero means do not wait: reply
+		// immediately with 503 and a Retry-After header.
+		Timeout time.Duration
+		// PollInterval is how often the gatekeeper is re-checked while waiting.
+		PollInterval time.Duration
+	}
 }
 
 // ParseFromEnvs parses the configuration from environment variables.
@@ -129,6 +137,25 @@ func ParseFromEnvs() (*Config, error) {
 		errs = errors.Join(errs, fmt.Errorf("ANICETUS_BACKEND_ADDRESS is required"))
 	} else if config.Backend.Address, err = url.Parse(addressStr); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to parse ANICETUS_BACKEND_ADDRESS: %w", err))
+	}
+
+	// Zero disables waiting: blocked requests get an immediate 503 + Retry-After.
+	if waitTimeoutStr := os.Getenv("ANICETUS_WAIT_TIMEOUT"); waitTimeoutStr != "" {
+		config.Wait.Timeout, err = time.ParseDuration(waitTimeoutStr)
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to parse ANICETUS_WAIT_TIMEOUT: %w", err))
+		}
+	}
+
+	config.Wait.PollInterval = 50 * time.Millisecond
+	if pollIntervalStr := os.Getenv("ANICETUS_WAIT_POLL_INTERVAL"); pollIntervalStr != "" {
+		config.Wait.PollInterval, err = time.ParseDuration(pollIntervalStr)
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to parse ANICETUS_WAIT_POLL_INTERVAL: %w", err))
+		}
+	}
+	if config.Wait.Timeout > 0 && config.Wait.PollInterval <= 0 {
+		errs = errors.Join(errs, fmt.Errorf("ANICETUS_WAIT_POLL_INTERVAL must be greater than zero"))
 	}
 
 	if errs != nil {

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -1,12 +1,19 @@
 package http
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/rafaeljusto/anicetus/v3"
 	"github.com/rafaeljusto/anicetus/v3/fingerprint"
 )
+
+// retryAfterSeconds is the Retry-After value sent to a blocked request that is
+// not served, telling the client how long to back off before retrying.
+const retryAfterSeconds = 1
 
 // RegisterHandlers registers the handlers for the web server.
 func RegisterHandlers(router *http.ServeMux, config *Config, resources *Resources) {
@@ -48,6 +55,13 @@ func anicetusHandler(config *Config, resources *Resources) http.HandlerFunc {
 			return
 		}
 
+		// When configured to wait, hold a blocked request until the elected
+		// request finishes (so it can be served from the warm cache) instead of
+		// rejecting it immediately.
+		if gatekeeperStatus == anicetus.StatusWait && config.Wait.Timeout > 0 {
+			gatekeeperStatus = waitForGate(r.Context(), config, resources, fingerprint, httpLogger)
+		}
+
 		switch gatekeeperStatus {
 		case anicetus.StatusFailed:
 			w.WriteHeader(http.StatusInternalServerError)
@@ -77,6 +91,9 @@ func anicetusHandler(config *Config, resources *Resources) http.HandlerFunc {
 			}
 
 		case anicetus.StatusWait:
+			// Either waiting is disabled or we waited out the timeout without the
+			// elected request finishing. Ask the client to retry.
+			w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds))
 			w.WriteHeader(http.StatusServiceUnavailable)
 
 		case anicetus.StatusOpenGates:
@@ -88,6 +105,43 @@ func anicetusHandler(config *Config, resources *Resources) http.HandlerFunc {
 					slog.String("error", err.Error()),
 				)
 				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}
+	}
+}
+
+// waitForGate blocks until the request is no longer waiting behind the elected
+// request -- either because that request finished (StatusOpenGates) or because
+// its lease expired and this request was elected instead (StatusProcess) -- or
+// until the configured wait timeout elapses. It returns the resolved status,
+// which is StatusWait when the timeout is reached.
+func waitForGate(
+	ctx context.Context,
+	config *Config,
+	resources *Resources,
+	f fingerprint.HTTPRequest,
+	logger *slog.Logger,
+) anicetus.Status {
+	ctx, cancel := context.WithTimeout(ctx, config.Wait.Timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(config.Wait.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return anicetus.StatusWait
+		case <-ticker.C:
+			status, err := resources.Anicetus.Evaluate(ctx, f)
+			if err != nil {
+				logger.Error("failed to re-evaluate fingerprint while waiting",
+					slog.String("error", err.Error()),
+				)
+				return anicetus.StatusFailed
+			}
+			if status != anicetus.StatusWait {
+				return status
 			}
 		}
 	}

--- a/internal/http/handlers_test.go
+++ b/internal/http/handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rafaeljusto/anicetus/v3"
 	"github.com/rafaeljusto/anicetus/v3/fingerprint"
 )
 
@@ -47,6 +48,128 @@ func newTestHandler(t *testing.T) (http.HandlerFunc, *atomic.Int64) {
 	t.Cleanup(func() { _ = resources.Close() })
 
 	return anicetusHandler(config, resources), &backendHits
+}
+
+// blockingBackend is a backend that blocks the elected (StatusProcess) request
+// until released, letting a test hold the gate open while another request with
+// the same fingerprint is evaluated.
+type blockingBackend struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+// newWaitTestHandler wires a handler in front of a blocking backend with the
+// given wait timeout. The detector uses a burst of one so the first request is
+// allowed through and drains the bucket, and every subsequent request with the
+// same fingerprint is treated as a thundering herd.
+func newWaitTestHandler(t *testing.T, waitTimeout time.Duration) (http.HandlerFunc, *blockingBackend) {
+	t.Helper()
+
+	bb := &blockingBackend{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Anicetus-Status") == anicetus.StatusProcess.String() {
+			bb.entered <- struct{}{}
+			<-bb.release
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(backend.Close)
+
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("failed to parse backend url: %v", err)
+	}
+
+	config := &Config{}
+	config.LoggerLevel = slog.LevelError
+	config.Detector.RequestsPerMinute = 1
+	config.Detector.CoolDown = time.Minute
+	config.Backend.Timeout = time.Minute
+	config.Backend.Address = backendURL
+	config.Fingerprint.Fields = []fingerprint.HTTPRequestField{
+		fingerprint.HTTPRequestFieldMethod,
+		fingerprint.HTTPRequestFieldPath,
+	}
+	config.Wait.Timeout = waitTimeout
+	config.Wait.PollInterval = 10 * time.Millisecond
+
+	resources := NewResources(config)
+	t.Cleanup(func() { _ = resources.Close() })
+
+	return anicetusHandler(config, resources), bb
+}
+
+// get issues a GET for the shared fingerprint and returns the response recorder.
+func get(handler http.HandlerFunc) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	handler(rr, httptest.NewRequest(http.MethodGet, "/resource", nil))
+	return rr
+}
+
+// TestAnicetusHandler_waitDisabledReturns503 checks that with waiting disabled a
+// blocked request is rejected immediately with 503 and a Retry-After header.
+func TestAnicetusHandler_waitDisabledReturns503(t *testing.T) {
+	handler, bb := newWaitTestHandler(t, 0)
+
+	// Drain the bucket so the following requests are treated as a herd.
+	get(handler)
+
+	// The elected request holds the gate open inside the backend.
+	electedDone := make(chan struct{})
+	go func() {
+		defer close(electedDone)
+		get(handler)
+	}()
+	<-bb.entered
+
+	rr := get(handler)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status %d, got %d", http.StatusServiceUnavailable, rr.Code)
+	}
+	if rr.Header().Get("Retry-After") == "" {
+		t.Error("expected Retry-After header to be set")
+	}
+
+	close(bb.release)
+	<-electedDone
+}
+
+// TestAnicetusHandler_waitHoldsThenForwards checks that with waiting enabled a
+// blocked request is held and then forwarded once the elected request finishes.
+func TestAnicetusHandler_waitHoldsThenForwards(t *testing.T) {
+	handler, bb := newWaitTestHandler(t, 2*time.Second)
+
+	get(handler) // drain the bucket
+
+	electedDone := make(chan struct{})
+	go func() {
+		defer close(electedDone)
+		get(handler)
+	}()
+	<-bb.entered
+
+	waiterDone := make(chan int, 1)
+	go func() {
+		waiterDone <- get(handler).Code
+	}()
+
+	// Release the elected request; the waiter must then be forwarded.
+	close(bb.release)
+	<-electedDone
+
+	select {
+	case code := <-waiterDone:
+		if code != http.StatusOK {
+			t.Errorf("expected waiting request to be forwarded with %d, got %d", http.StatusOK, code)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("waiting request did not complete in time")
+	}
 }
 
 // TestAnicetusHandler_forwardsNonGetOnce is the regression test for the missing


### PR DESCRIPTION
## Summary

The HTTP service used to answer every blocked request (`StatusWait`) with an immediate `503`, so the "blocked requests are released once the first finishes" behaviour the library models never actually happened over HTTP — clients were just rejected and had to retry blind. This adds a configurable wait so the service can honour that promise, while keeping the immediate-reject option.

## Behaviour

New `ANICETUS_WAIT_TIMEOUT` (default `0`):

- **`0` (default)** — reply immediately, but now with a `Retry-After` header so clients back off sensibly instead of hammering.
- **`>0`** — hold the blocked request, polling the gatekeeper every `ANICETUS_WAIT_POLL_INTERVAL` (default `50ms`), and forward it once:
  - the elected request finishes (served from the now-warm cache), or
  - the elected request's lease expires and this request is elected instead (handled as `StatusProcess`).
  - If the timeout elapses first, fall back to `503` + `Retry-After`.

The wait is bounded by the timeout, and re-evaluating the gatekeeper is idempotent (`Add` only writes when absent), so polling doesn't disturb the elected entry.

## Tests

- `waitDisabledReturns503` — blocked request gets `503` + `Retry-After`.
- `waitHoldsThenForwards` — blocked request is held, then forwarded with `200` once the elected request finishes.

Both run green 5× under `-race`. Full unit suite passes, gofmt/vet clean.

## Notes

- No API breaking changes; new config only.
- **Separately found:** `ANICETUS_DETECTOR_REQUESTS_PER_MINUTE=0` crashes the service — `burst=0` makes the token-bucket limiter's map TTL `0`, and `mapexp.New` calls `time.NewTicker(0)` which panics. Not fixed here (out of scope); worth a follow-up guard in `mapexp.New`.
- Commit is unsigned (GPG can't prompt in my environment); re-sign before merge if required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)