### PR TITLE
Fix: Do not panic on non-positive expiry TTL

### DIFF
--- a/detector/tokenbucket_inmemory_test.go
+++ b/detector/tokenbucket_inmemory_test.go
@@ -70,3 +70,24 @@ func TestTokenBucketInMemory_IsThunderingHerd(t *testing.T) {
 		})
 	}
 }
+
+// TestTokenBucketInMemory_zeroConfig ensures a burst or cooldown of zero does
+// not panic when constructing the detector (the internal expiry maps would
+// otherwise start a ticker with a non-positive interval). Such a configuration
+// simply treats every request as a thundering herd.
+func TestTokenBucketInMemory_zeroConfig(t *testing.T) {
+	d := detector.NewTokenBucketInMemory(
+		detector.TokenBucketWithLimitersBurst(0),
+		detector.TokenBucketWithLimitersInterval(time.Minute),
+		detector.TokenBucketWithCoolDownInterval(0),
+	)
+	t.Cleanup(func() { _ = d.Close() })
+
+	herd, err := d.IsThunderingHerd(t.Context(), anicetus.Fingerprint("test"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !herd {
+		t.Error("expected a burst of zero to always report a thundering herd")
+	}
+}

--- a/internal/mapexp/map.go
+++ b/internal/mapexp/map.go
@@ -15,14 +15,19 @@ type Map[K comparable, V any] struct {
 	stopOnce sync.Once
 }
 
-// New creates a new Map.
+// New creates a new Map. A non-positive ttl disables expiration: entries are
+// kept until explicitly deleted and no background goroutine is started. This
+// also avoids panicking on time.NewTicker, which rejects non-positive
+// intervals.
 func New[K comparable, V any](ttl time.Duration) *Map[K, V] {
 	m := &Map[K, V]{
 		items:           make(map[K]V),
 		expirationQueue: newExpirationQueue[K](ttl),
 		stop:            make(chan struct{}),
 	}
-	m.start()
+	if ttl > 0 {
+		m.start()
+	}
 	return m
 }
 

--- a/internal/mapexp/mapexp_test.go
+++ b/internal/mapexp/mapexp_test.go
@@ -40,3 +40,19 @@ func TestMap_StopIsIdempotent(*testing.T) {
 	m.Stop()
 	m.Stop()
 }
+
+// TestMap_NonPositiveTTL guards against time.NewTicker panicking on a
+// non-positive interval: a non-positive ttl must disable expiration rather than
+// crash. Entries are kept and Stop stays safe.
+func TestMap_NonPositiveTTL(t *testing.T) {
+	for _, ttl := range []time.Duration{0, -time.Second} {
+		m := New[string, int](ttl)
+
+		m.Set("key", 1)
+		if value, ok := m.Get("key"); !ok || value != 1 {
+			t.Errorf("ttl %s: expected key to be kept, got value %d ok %t", ttl, value, ok)
+		}
+
+		m.Stop()
+	}
+}


### PR DESCRIPTION
## Summary

A detector configured with `ANICETUS_DETECTOR_REQUESTS_PER_MINUTE=0` (burst 0) or `ANICETUS_DETECTOR_COOLDOWN=0` **crashed the service**. The internal `mapexp.Map` computed a TTL of zero and called `time.NewTicker(0)`, which panics on a non-positive interval. Found while writing the wait tests for #20.

## Fix

Guard `mapexp.New`: a non-positive TTL now disables expiration (no janitor goroutine, entries kept until deleted) instead of panicking. This covers both the limiters map (burst 0) and the cooldowns map (cooldown 0). A burst of zero becomes a valid "always a thundering herd" configuration.

## Tests

- `mapexp.New` tolerates zero and negative TTL (entries kept, `Stop` safe).
- Token bucket detector constructs with burst 0 and cooldown 0 without panicking and reports a herd.

Full unit suite green, race-clean, gofmt/vet clean.

## Notes

- No API or behaviour change for valid configs; purely removes a crash.
- Commit unsigned (GPG can't prompt in my environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)